### PR TITLE
changed to alternate wayback cdx server

### DIFF
--- a/cdx_toolkit/__init__.py
+++ b/cdx_toolkit/__init__.py
@@ -318,7 +318,7 @@ class CDXFetcher:
         if source == 'cc':
             self.raw_index_list = get_cc_endpoints()
         elif source == 'ia':
-            self.index_list = ('https://web.archive.org/cdx/search/cdx',)
+            self.index_list = ('https://web.archive.org/web/timemap/json',)
         elif source.startswith('https://') or source.startswith('http://'):
             self.index_list = (source,)
         else:


### PR DESCRIPTION
https://web.archive.org/web/timemap/json and https://web.archive.org/web/timemap/xd return an extra "filename" field like pywb/common crawl do. Filenames correspond to warc and arc files located in archive.org collection items. Item metadata can be accessed using archive.org's metadata api and files which are publicly accessible can be downloaded in whole or in part similarly to commoncrawl warcs on s3.

http://blog.archive.org/2013/07/04/metadata-api/